### PR TITLE
support double quotation in ref function

### DIFF
--- a/sqlfluff_templater_dataform/templater.py
+++ b/sqlfluff_templater_dataform/templater.py
@@ -19,7 +19,7 @@ templater_logger = logging.getLogger("sqlfluff.templater")
 # regex pattern for config block and js block
 CONFIG_BLOCK_PATTERN = r'config\s*\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\}'
 JS_BLOCK_PATTERN = r'js\s*\{(?:[^{}]|\{[^{}]*\})*\}'
-REF_PATTERN = r'\$\{\s*ref\(\s*\'([^\']+)\'(?:\s*,\s*\'([^\']+)\')?\s*\)\s*\}'
+REF_PATTERN = r'\$\{\s*ref\(\s*[\'"]([^\'"]+)[\'"](?:\s*,\s*[\'"]([^\'"]+)[\'"])?\s*\)\s*\}'
 
 class UsedJSBlockError(SQLFluffSkipFile):
     """ This package does not support dataform js block """

--- a/test/fixtures/dataform/definitions/test.sqlx
+++ b/test/fixtures/dataform/definitions/test.sqlx
@@ -18,7 +18,7 @@ WITH users AS (
 select user_id,
     name,
         age
-    from ${ref('users')}
+    from ${ref("users")}
 )
 , user_orders AS (
     select user_id, order_id, DATE(created_at) AS order_date from ${ref('user_orders')}

--- a/test/templater_test.py
+++ b/test/templater_test.py
@@ -29,8 +29,20 @@ def test_replace_ref_with_bq_table_single_ref(templater):
     result = templater.replace_ref_with_bq_table(input_sql)
     assert result == expected_sql
 
+def test_replace_ref_with_bq_table_single_ref_double_quotes(templater):
+    input_sql = 'SELECT * FROM ${ref("test")}'
+    expected_sql = "SELECT * FROM `my_project.my_dataset.test`"
+    result = templater.replace_ref_with_bq_table(input_sql)
+    assert result == expected_sql
+
 def test_replace_ref_with_bq_table_with_dataset(templater):
     input_sql = "SELECT * FROM ${ref('other_dataset', 'test')}"
+    expected_sql = "SELECT * FROM `my_project.other_dataset.test`"
+    result = templater.replace_ref_with_bq_table(input_sql)
+    assert result == expected_sql
+
+def test_replace_ref_with_bq_table_with_dataset_double_quotes(templater):
+    input_sql = 'SELECT * FROM ${ref("other_dataset", "test")}'
     expected_sql = "SELECT * FROM `my_project.other_dataset.test`"
     result = templater.replace_ref_with_bq_table(input_sql)
     assert result == expected_sql


### PR DESCRIPTION
Hi, Thank you for the wonderful feature:)

Our team encountered an error when using double quotes within the Ref function, so I have submitted a PR to address the issue with double quotes.

reference
- https://cloud.google.com/dataform/docs/dependencies?hl=ja#ref-dependencies

Observed errors with `test.sqlx` (could not read parse double quotation within Ref function)

```bash
[L:  1, P:  1]      |file:
[L:  1, P:  1]      |    [META] placeholder:                                       [Type: 'templated', Raw: 'config {\n    type: "table",\n    schema: "schama",\n    tags: [\n        "test"\n    ],\n    description: "test sqlx file for lint by sqlfluff-templater-dataform.",\n    columns: {\n        user_id: "ユーザーID",\n        name: "ユーザー名",\n        age: "年齢",\n        order_date: "注文日",\n        order_count: "注文回数"\n    }\n}']
[L: 15, P:  2]      |    newline:                                                  '\n'
[L: 16, P:  1]      |    newline:                                                  '\n'
[L: 17, P:  1]      |    statement:
[L: 17, P:  1]      |        with_compound_statement:
[L: 17, P:  1]      |            keyword:                                          'WITH'
[L: 17, P:  5]      |            whitespace:                                       ' '
[L: 17, P:  6]      |            common_table_expression:
[L: 17, P:  6]      |                naked_identifier:                             'users'
[L: 17, P: 11]      |                whitespace:                                   ' '
[L: 17, P: 12]      |                keyword:                                      'AS'
[L: 17, P: 14]      |                whitespace:                                   ' '
[L: 17, P: 15]      |                bracketed:
[L: 17, P: 15]      |                    start_bracket:                            '('
[L: 17, P: 16]      |                    [META] indent:
[L: 17, P: 16]      |                    newline:                                  '\n'
[L: 18, P:  1]      |                    select_statement:
[L: 18, P:  1]      |                        select_clause:
[L: 18, P:  1]      |                            keyword:                          'select'
[L: 18, P:  7]      |                            [META] indent:
[L: 18, P:  7]      |                            whitespace:                       ' '
[L: 18, P:  8]      |                            select_clause_element:
[L: 18, P:  8]      |                                column_reference:
[L: 18, P:  8]      |                                    naked_identifier:         'user_id'
[L: 18, P: 15]      |                            comma:                            ','
[L: 18, P: 16]      |                            newline:                          '\n'
[L: 19, P:  1]      |                            whitespace:                       '    '
[L: 19, P:  5]      |                            select_clause_element:
[L: 19, P:  5]      |                                column_reference:
[L: 19, P:  5]      |                                    naked_identifier:         'name'
[L: 19, P:  9]      |                            comma:                            ','
[L: 19, P: 10]      |                            newline:                          '\n'
[L: 20, P:  1]      |                            whitespace:                       '        '
[L: 20, P:  9]      |                            select_clause_element:
[L: 20, P:  9]      |                                column_reference:
[L: 20, P:  9]      |                                    naked_identifier:         'age'
[L: 20, P: 12]      |                            [META] dedent:
[L: 20, P: 12]      |                        newline:                              '\n'
[L: 21, P:  1]      |                        whitespace:                           '    '
[L: 21, P:  5]      |                        unparsable:                           !! Expected: 'Nothing here.'
[L: 21, P:  5]      |                            word:                             'from'
[L: 21, P:  9]      |                            whitespace:                       ' '
[L: 21, P: 10]      |                            <unlexable>:                      '${ref("users")}'
[L: 21, P: 25]      |                    newline:                                  '\n'
[L: 22, P:  1]      |                    [META] dedent:
[L: 22, P:  1]      |                    end_bracket:                              ')'
[L: 22, P:  2]      |            newline:                                          '\n'
[L: 23, P:  1]      |            comma:                                            ','
[L: 23, P:  2]      |            whitespace:                                       ' '
[L: 23, P:  3]      |            common_table_expression:
[L: 23, P:  3]      |                naked_identifier:                             'user_orders'
[L: 23, P: 14]      |                whitespace:                                   ' '
[L: 23, P: 15]      |                keyword:                                      'AS'
[L: 23, P: 17]      |                whitespace:                                   ' '
[L: 23, P: 18]      |                bracketed:
[L: 23, P: 18]      |                    start_bracket:                            '('
[L: 23, P: 19]      |                    [META] indent:
[L: 23, P: 19]      |                    newline:                                  '\n'
[L: 24, P:  1]      |                    whitespace:                               '    '
[L: 24, P:  5]      |                    select_statement:
[L: 24, P:  5]      |                        select_clause:
[L: 24, P:  5]      |                            keyword:                          'select'
[L: 24, P: 11]      |                            [META] indent:
[L: 24, P: 11]      |                            whitespace:                       ' '
[L: 24, P: 12]      |                            select_clause_element:
[L: 24, P: 12]      |                                column_reference:
[L: 24, P: 12]      |                                    naked_identifier:         'user_id'
[L: 24, P: 19]      |                            comma:                            ','
[L: 24, P: 20]      |                            whitespace:                       ' '
[L: 24, P: 21]      |                            select_clause_element:
[L: 24, P: 21]      |                                column_reference:
[L: 24, P: 21]      |                                    naked_identifier:         'order_id'
[L: 24, P: 29]      |                            comma:                            ','
[L: 24, P: 30]      |                            whitespace:                       ' '
[L: 24, P: 31]      |                            select_clause_element:
[L: 24, P: 31]      |                                function:
[L: 24, P: 31]      |                                    function_name:
[L: 24, P: 31]      |                                        function_name_identifier:  'DATE'
[L: 24, P: 35]      |                                    function_contents:
[L: 24, P: 35]      |                                        bracketed:
[L: 24, P: 35]      |                                            start_bracket:    '('
[L: 24, P: 36]      |                                            [META] indent:
[L: 24, P: 36]      |                                            expression:
[L: 24, P: 36]      |                                                column_reference:
[L: 24, P: 36]      |                                                    naked_identifier:  'created_at'
[L: 24, P: 46]      |                                            [META] dedent:
[L: 24, P: 46]      |                                            end_bracket:      ')'
[L: 24, P: 47]      |                                whitespace:                   ' '
[L: 24, P: 48]      |                                alias_expression:
[L: 24, P: 48]      |                                    [META] indent:
[L: 24, P: 48]      |                                    keyword:                  'AS'
[L: 24, P: 50]      |                                    whitespace:               ' '
[L: 24, P: 51]      |                                    naked_identifier:         'order_date'
[L: 24, P: 61]      |                                    [META] dedent:
[L: 24, P: 61]      |                            [META] dedent:
[L: 24, P: 61]      |                        whitespace:                           ' '
[L: 24, P: 62]      |                        from_clause:
[L: 24, P: 62]      |                            keyword:                          'from'
[L: 24, P: 66]      |                            whitespace:                       ' '
[L: 24, P: 67]      |                            from_expression:
[L: 24, P: 67]      |                                [META] indent:
[L: 24, P: 67]      |                                from_expression_element:
[L: 24, P: 67]      |                                    table_expression:
[L: 24, P: 67]      |                                        table_reference:
[L: 24, P: 67]      |                                            quoted_identifier:  '`None.None.user_orders`'
[L: 24, P: 88]      |                                [META] dedent:
[L: 24, P: 88]      |                    newline:                                  '\n'
[L: 25, P:  1]      |                    [META] dedent:
[L: 25, P:  1]      |                    end_bracket:                              ')'
[L: 25, P:  2]      |            newline:                                          '\n'
[L: 26, P:  1]      |            select_statement:
[L: 26, P:  1]      |                select_clause:
[L: 26, P:  1]      |                    keyword:                                  'SELECt'
[L: 26, P:  7]      |                    [META] indent:
[L: 26, P:  7]      |                    whitespace:                               ' '
[L: 26, P:  8]      |                    select_clause_element:
[L: 26, P:  8]      |                        column_reference:
[L: 26, P:  8]      |                            naked_identifier:                 'users'
[L: 26, P: 13]      |                            dot:                              '.'
[L: 26, P: 14]      |                            naked_identifier:                 'user_id'
[L: 26, P: 21]      |                    comma:                                    ','
[L: 26, P: 22]      |                    whitespace:                               ' '
[L: 26, P: 23]      |                    select_clause_element:
[L: 26, P: 23]      |                        column_reference:
[L: 26, P: 23]      |                            naked_identifier:                 'name'
[L: 26, P: 27]      |                    comma:                                    ','
[L: 26, P: 28]      |                    whitespace:                               ' '
[L: 26, P: 29]      |                    select_clause_element:
[L: 26, P: 29]      |                        column_reference:
[L: 26, P: 29]      |                            naked_identifier:                 'age'
[L: 26, P: 32]      |                    comma:                                    ','
[L: 26, P: 33]      |                    whitespace:                               ' '
[L: 26, P: 34]      |                    select_clause_element:
[L: 26, P: 34]      |                        column_reference:
[L: 26, P: 34]      |                            naked_identifier:                 'order_date'
[L: 26, P: 44]      |                    comma:                                    ','
[L: 26, P: 45]      |                    whitespace:                               ' '
[L: 26, P: 46]      |                    select_clause_element:
[L: 26, P: 46]      |                        function:
[L: 26, P: 46]      |                            function_name:
[L: 26, P: 46]      |                                function_name_identifier:     'count'
[L: 26, P: 51]      |                            function_contents:
[L: 26, P: 51]      |                                bracketed:
[L: 26, P: 51]      |                                    start_bracket:            '('
[L: 26, P: 52]      |                                    [META] indent:
[L: 26, P: 52]      |                                    expression:
[L: 26, P: 52]      |                                        column_reference:
[L: 26, P: 52]      |                                            naked_identifier:  'order_id'
[L: 26, P: 60]      |                                    [META] dedent:
[L: 26, P: 60]      |                                    end_bracket:              ')'
[L: 26, P: 61]      |                        whitespace:                           ' '
[L: 26, P: 62]      |                        alias_expression:
[L: 26, P: 62]      |                            [META] indent:
[L: 26, P: 62]      |                            keyword:                          'AS'
[L: 26, P: 64]      |                            whitespace:                       ' '
[L: 26, P: 65]      |                            naked_identifier:                 'order_count'
[L: 26, P: 76]      |                            [META] dedent:
[L: 26, P: 76]      |                    [META] dedent:
[L: 26, P: 76]      |                newline:                                      '\n'
[L: 27, P:  1]      |                from_clause:
[L: 27, P:  1]      |                    keyword:                                  'from'
[L: 27, P:  5]      |                    whitespace:                               ' '
[L: 27, P:  6]      |                    from_expression:
[L: 27, P:  6]      |                        [META] indent:
[L: 27, P:  6]      |                        from_expression_element:
[L: 27, P:  6]      |                            table_expression:
[L: 27, P:  6]      |                                table_reference:
[L: 27, P:  6]      |                                    naked_identifier:         'users'
[L: 27, P: 11]      |                        whitespace:                           ' '
[L: 27, P: 12]      |                        [META] dedent:
[L: 27, P: 12]      |                        join_clause:
[L: 27, P: 12]      |                            keyword:                          'left'
[L: 27, P: 16]      |                            whitespace:                       ' '
[L: 27, P: 17]      |                            keyword:                          'outer'
[L: 27, P: 22]      |                            whitespace:                       ' '
[L: 27, P: 23]      |                            keyword:                          'join'
[L: 27, P: 27]      |                            [META] indent:
[L: 27, P: 27]      |                            whitespace:                       ' '
[L: 27, P: 28]      |                            from_expression_element:
[L: 27, P: 28]      |                                table_expression:
[L: 27, P: 28]      |                                    table_reference:
[L: 27, P: 28]      |                                        naked_identifier:     'user_orders'
[L: 27, P: 39]      |                            whitespace:                       ' '
[L: 27, P: 40]      |                            [META] dedent:
[L: 27, P: 40]      |                            [META] indent:
[L: 27, P: 40]      |                            join_on_condition:
[L: 27, P: 40]      |                                keyword:                      'on'
[L: 27, P: 42]      |                                [META] (implicit) indent:
[L: 27, P: 42]      |                                whitespace:                   ' '
[L: 27, P: 43]      |                                expression:
[L: 27, P: 43]      |                                    column_reference:
[L: 27, P: 43]      |                                        naked_identifier:     'users'
[L: 27, P: 48]      |                                        dot:                  '.'
[L: 27, P: 49]      |                                        naked_identifier:     'user_id'
[L: 27, P: 56]      |                                    whitespace:               ' '
[L: 27, P: 57]      |                                    comparison_operator:
[L: 27, P: 57]      |                                        raw_comparison_operator:  '='
[L: 27, P: 58]      |                                    whitespace:               ' '
[L: 27, P: 59]      |                                    column_reference:
[L: 27, P: 59]      |                                        naked_identifier:     'user_orders'
[L: 27, P: 70]      |                                        dot:                  '.'
[L: 27, P: 71]      |                                        naked_identifier:     'user_id'
[L: 27, P: 78]      |                                [META] dedent:
[L: 27, P: 78]      |                            [META] dedent:
[L: 27, P: 78]      |                newline:                                      '\n'
[L: 28, P:  1]      |                groupby_clause:
[L: 28, P:  1]      |                    keyword:                                  'group'
[L: 28, P:  6]      |                    whitespace:                               ' '
[L: 28, P:  7]      |                    keyword:                                  'by'
[L: 28, P:  9]      |                    [META] indent:
[L: 28, P:  9]      |                    whitespace:                               ' '
[L: 28, P: 10]      |                    column_reference:
[L: 28, P: 10]      |                        naked_identifier:                     'user_id'
[L: 28, P: 17]      |                    comma:                                    ','
[L: 28, P: 18]      |                    whitespace:                               ' '
[L: 28, P: 19]      |                    column_reference:
[L: 28, P: 19]      |                        naked_identifier:                     'name'
[L: 28, P: 23]      |                    comma:                                    ','
[L: 28, P: 24]      |                    whitespace:                               ' '
[L: 28, P: 25]      |                    column_reference:
[L: 28, P: 25]      |                        naked_identifier:                     'age'
[L: 28, P: 28]      |                    comma:                                    ','
[L: 28, P: 29]      |                    whitespace:                               ' '
[L: 28, P: 30]      |                    column_reference:
[L: 28, P: 30]      |                        naked_identifier:                     'order_date'
[L: 28, P: 40]      |                    [META] dedent:
[L: 28, P: 40]      |    [META] end_of_file:

==== parsing violations ====
L:  21 | P:  10 |  LXR | Unable to lex characters: '${ref("use...'
L:  21 | P:   5 |  PRS | Line 7, Position 5: Found unparsable section: 'from
                       | ${ref("users")}'
WARNING: Parsing errors found and dialect is set to 'bigquery'. Have you configured your dialect correctly?
```