### PR TITLE
feat: Support extracting and linting pre/post_operations blocks

### DIFF
--- a/sqlfluff_templater_dataform/templater.py
+++ b/sqlfluff_templater_dataform/templater.py
@@ -136,7 +136,7 @@ class DataformTemplater(RawTemplater):
         Returns:
             The input string with all Dataform blocks removed
         """
-        block_keywords = ['config', 'pre_operations', 'post_operations', 'js']
+        block_keywords = ['config', 'js']
         for keyword in block_keywords:
             pattern = rf'{re.escape(keyword)}\s*\{{'
             while True:
@@ -147,6 +147,27 @@ class DataformTemplater(RawTemplater):
                 end = self.find_block_end(in_str, start)
                 if end != -1:
                     in_str = in_str[:match.start()] + in_str[end:]
+                else:
+                    break  # invalid, stop
+        return in_str
+
+    def extract_operation_blocks(self, in_str: str) -> str:
+        """Extract SQL from pre/post_operations blocks and append a semicolon if missing."""
+        block_keywords = ['pre_operations', 'post_operations']
+        for keyword in block_keywords:
+            pattern = rf'{re.escape(keyword)}\s*\{{'
+            while True:
+                match = re.search(pattern, in_str)
+                if not match:
+                    break
+                start = match.end() - 1  # position of {
+                end = self.find_block_end(in_str, start)
+                if end != -1:
+                    inner_sql = in_str[start+1:end-1].strip()
+                    if inner_sql and not inner_sql.endswith(";"):
+                        inner_sql += ";"
+                    replacement = f"\n{inner_sql}\n" if inner_sql else ""
+                    in_str = in_str[:match.start()] + replacement + in_str[end:]
                 else:
                     break  # invalid, stop
         return in_str
@@ -427,6 +448,7 @@ class DataformTemplater(RawTemplater):
             - templated_slices: List of TemplatedFileSlice objects for mapping
         """
         replaced_sql = self.replace_blocks(sql)
+        replaced_sql = self.extract_operation_blocks(replaced_sql)
         replaced_sql = self.replace_self_with_bq_table(replaced_sql)
         replaced_sql = self.replace_ref_with_bq_table(replaced_sql)
         replaced_sql = self.replace_incremental_condition(replaced_sql)
@@ -532,7 +554,33 @@ class DataformTemplater(RawTemplater):
 
             match_raw = sql[next_match_start:next_match_end]
 
-            if next_match_type == 'templated' and match_raw.startswith('${') and 'ref(' in match_raw:
+            if next_match_type == 'templated' and re.match(r'^(pre_operations|post_operations)\s*\{', match_raw):
+                brace_start = match_raw.find('{')
+                inner_sql = match_raw[brace_start+1:-1].strip()
+                if inner_sql and not inner_sql.endswith(";"):
+                    inner_sql += ";"
+                
+                op_replaced = inner_sql
+                if op_replaced:
+                    op_replaced = self.replace_self_with_bq_table(op_replaced)
+                    op_replaced = self.replace_ref_with_bq_table(op_replaced)
+                    op_replaced = self.replace_incremental_condition(op_replaced)
+                    op_replaced = self.replace_js_expressions(op_replaced)
+                    op_replaced = f"\n{op_replaced}\n"
+                
+                raw_slices.append(RawFileSlice(
+                    raw=match_raw,
+                    slice_type='templated',
+                    source_idx=next_match_start,
+                    block_idx=block_idx
+                ))
+                templated_slices.append(TemplatedFileSlice(
+                    slice_type=next_match_type,
+                    source_slice=slice(next_match_start, next_match_end),
+                    templated_slice=slice(templated_idx, templated_idx + len(op_replaced))
+                ))
+                templated_idx += len(op_replaced)
+            elif next_match_type == 'templated' and match_raw.startswith('${') and 'ref(' in match_raw:
                 ref_replaced = self.replace_ref_with_bq_table(match_raw)
                 raw_slices.append(RawFileSlice(
                     raw=match_raw,

--- a/test/templater_test.py
+++ b/test/templater_test.py
@@ -58,40 +58,18 @@ def test_replace_self_with_bq_table(templater):
                 ""
         ),
         (
-                """pre_operations {
-                CREATE TEMP FUNCTION AddFourAndDivide(x INT64, y INT64)
-                    RETURNS FLOAT64
-                    AS ((x + 4) / y);
-                }""",
-                ""
-        ),
-        (
-                """post_operations {
-                GRANT `roles/bigquery.dataViewer`
-                ON
-                TABLE ${self()}
-                TO "group:allusers@example.com", "user:otheruser@example.com"
+                """js {
+                const a = 1;
                 }""",
                 ""
         ),
         (
                 """config {
                 type: "table",
-                columns: {
-                    "test" : "test",
-                    "value:: "value"
-                }
-                } pre_operations {
-                CREATE TEMP FUNCTION AddFourAndDivide(x INT64, y INT64)
-                    RETURNS FLOAT64
-                    AS ((x + 4) / y);
-                } post_operations {
-                GRANT `roles/bigquery.dataViewer`
-                ON
-                TABLE ${self()}
-                TO "group:allusers@example.com", "user:otheruser@example.com"
+                } js {
+                const b = 2;
                 }""",
-                "  "
+                " "
         ),
     ]
 )
@@ -101,6 +79,25 @@ def test_replace_blocks(templater, test_block, replaced_sql):
     expected_sql = f"{replaced_sql} {sql_body}"
     result = templater.replace_blocks(input_sql)
     assert result == expected_sql
+
+
+def test_extract_operation_blocks(templater):
+    input_sql = """pre_operations {
+    CREATE TEMP FUNCTION AddFourAndDivide(x INT64, y INT64)
+        RETURNS FLOAT64
+        AS ((x + 4) / y)
+    } post_operations {
+    GRANT `roles/bigquery.dataViewer`
+    ON
+    TABLE ${self()}
+    TO "group:allusers@example.com", "user:otheruser@example.com";
+    } SELECT * FROM my_table"""
+
+    expected_sql = '\nCREATE TEMP FUNCTION AddFourAndDivide(x INT64, y INT64)\n        RETURNS FLOAT64\n        AS ((x + 4) / y);\n \nGRANT `roles/bigquery.dataViewer`\n    ON\n    TABLE ${self()}\n    TO "group:allusers@example.com", "user:otheruser@example.com";\n SELECT * FROM my_table'
+    
+    result = templater.extract_operation_blocks(input_sql)
+    assert result == expected_sql
+
 
 
 # slice_sqlx_template のテスト
@@ -275,7 +272,7 @@ post_operations {
   }
 }
 """
-    expected_sql = "\nSELECT * FROM `my_project.my_dataset.test`\n\n"
+    expected_sql = "\nSELECT * FROM `my_project.my_dataset.test`\n\nif (true) {\n    const result = `my_project.my_dataset.self`;\n    if (result) {\n      console.log('nested');\n    }\n  };\n\n"
     replaced_sql, raw_slices, templated_slices = templater.slice_sqlx_template(input_sqlx)
     assert replaced_sql == expected_sql
 
@@ -310,7 +307,7 @@ post_operations {
   END;
 }
 """
-    expected_sql = "\nSELECT * FROM `my_project.my_dataset.test`\n\n"
+    expected_sql = "\nSELECT * FROM `my_project.my_dataset.test`\n\nBEGIN\n    ALTER TABLE `my_project.my_dataset.self` DROP PRIMARY KEY IF EXISTS;\n    ALTER TABLE `my_project.my_dataset.self` ADD PRIMARY KEY (some_id, another_id) NOT ENFORCED;\n  END;\n\n"
     replaced_sql, raw_slices, templated_slices = templater.slice_sqlx_template(input_sqlx)
     assert replaced_sql == expected_sql
 
@@ -470,7 +467,7 @@ SELECT * FROM ${ref('test')} JOIN ${ref('other_table')} ON test.id = other_table
         (
             "config_pre_post_ref.sqlx",
             {
-                "expected_sql": "\n\n\nSELECT * FROM `my_project.my_dataset.test` WHERE true\n",
+                "expected_sql": "\n\nCREATE TEMP FUNCTION AddFourAndDivide(x INT64, y INT64)\nRETURNS FLOAT64\nAS ((x + 4) / y);\n\n\nGRANT `roles/bigquery.dataViewer`\n    ON\n    TABLE `my_project.my_dataset.self`\n    TO \"group:allusers@example.com\", \"user:otheruser@example.com\";\n\nSELECT * FROM `my_project.my_dataset.test` WHERE true\n",
                 "raw_slices": {
                     "len": 8,
                     "raw_starts": [
@@ -569,5 +566,3 @@ SELECT ${column_name} FROM ${self()}
 
     assert templated_slices[2].slice_type == "templated"
     assert templated_slices[4].slice_type == "templated"
-
-


### PR DESCRIPTION
## Overview
Instead of removing `pre_operations` and `post_operations` blocks, the templater now extracts the SQL inside them so they can be linted. Additionally, it automatically appends a semicolon (`;`) if one is missing, preventing SQLFluff parsing errors when multiple statements are joined.

## Changes
- Modified `DataformTemplater.replace_blocks` to keep operation blocks.
- Added `DataformTemplater.extract_operation_blocks` to handle SQL extraction and semicolon insertion.
- Updated `DataformTemplater.slice_sqlx_template` to correctly slice and map these blocks.
- Updated and added test cases in `test/templater_test.py` to verify the new behavior.

## Verification
- All tests in `test/templater_test.py` passed.
- Verified that operation blocks are now included in the templated SQL output.