### PR TITLE
fix: correctly slice ${when(...)} and multi-line ${ref(...)} blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,19 @@ templater = dataform
 dialect = bigquery
 sql_file_exts = .sql,.sqlx
 ```
+
+
+## Development
+
+With [mise](https://mise.jdx.dev) installed, run `mise install` from the repo
+root once to provision Python, `uv`, and a `.venv` directory. The first
+install fires a `postinstall` hook that runs `mise run sync`, which installs
+the test dependencies into the venv. After that:
+
+```bash
+mise run test     # run the test suite
+mise run sync     # re-install deps after pulling changes to requirements.txt
+pytest test/      # or invoke pytest directly (the venv is auto-activated)
+```
+
+The `compose.yml` / `Dockerfile.dev` setup remains for those who prefer it.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,17 @@
+[tools]
+python = "3.13"
+uv = "latest"
+
+[env]
+_.python.venv = { path = ".venv", create = true }
+
+[hooks]
+postinstall = "mise run sync"
+
+[tasks.sync]
+description = "Install Python dependencies into the venv (re-run after pulling changes)"
+run = "uv pip install -r requirements.txt -e ."
+
+[tasks.test]
+description = "Run the test suite"
+run = "pytest test/ -v"

--- a/sqlfluff_templater_dataform/templater.py
+++ b/sqlfluff_templater_dataform/templater.py
@@ -22,7 +22,7 @@ PRE_OPERATION_BLOCK_PATTERN = r'pre_operations\s*\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\
 POST_OPERATION_BLOCK_PATTERN = r'post_operations\s*\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*\}'
 JS_BLOCK_PATTERN = r'\s*js\s*\{(?:[^{}]|\{[^{}]*\})*\}'
 JS_EXPRESSION_PATTERN_IN_SQL = r'\$\{'
-REF_PATTERN = r'\$\{\s*ref\((.*?)\)\s*\}'
+REF_PATTERN = r'(?s)\$\{\s*ref\((.*?)\)\s*\}'
 SELF_PATTERN = r'\$\{\s*self\(\s*\)\s*\}'
 INCREMENTAL_CONDITION_PATTERN = r'\$\{\s*when\((.*?)\)\s*\}'
 
@@ -532,7 +532,12 @@ class DataformTemplater(RawTemplater):
 
             match_raw = sql[next_match_start:next_match_end]
 
-            if next_match_type == 'templated' and match_raw.startswith('${') and 'ref(' in match_raw:
+            # Dispatch on the construct that BEGINS the matched block. A
+            # ${when(...)} block can wrap ${self()} / ${ref()}; substring
+            # checks ('self(' in match_raw) would mis-route to the inner
+            # construct's branch and consume the entire outer block under
+            # the wrong replacement, breaking templated-slice lengths.
+            if next_match_type == 'templated' and re.match(r'\$\{\s*ref\(', match_raw):
                 ref_replaced = self.replace_ref_with_bq_table(match_raw)
                 raw_slices.append(RawFileSlice(
                     raw=match_raw,
@@ -546,7 +551,7 @@ class DataformTemplater(RawTemplater):
                     templated_slice=slice(templated_idx, templated_idx + len(ref_replaced))
                 ))
                 templated_idx += len(ref_replaced)
-            elif next_match_type == 'templated' and match_raw.startswith('${') and 'self(' in match_raw:
+            elif next_match_type == 'templated' and re.match(r'\$\{\s*self\(', match_raw):
                 self_replaced = self.replace_self_with_bq_table(match_raw)
                 raw_slices.append(RawFileSlice(
                     raw=match_raw,
@@ -560,8 +565,12 @@ class DataformTemplater(RawTemplater):
                     templated_slice=slice(templated_idx, templated_idx + len(self_replaced))
                 ))
                 templated_idx += len(self_replaced)
-            elif next_match_type == 'templated' and match_raw.startswith('${') and 'when(' in match_raw:
-                when_replaced = self.replace_incremental_condition(match_raw)
+            elif next_match_type == 'templated' and re.match(r'\$\{\s*when\(', match_raw):
+                # Resolve nested ${self()} / ${ref()} first — INCREMENTAL_CONDITION_PATTERN
+                # is non-greedy and would otherwise close the match at the inner `)}`.
+                # Mirrors the global pass order in slice_sqlx_template above.
+                pre = self.replace_ref_with_bq_table(self.replace_self_with_bq_table(match_raw))
+                when_replaced = self.replace_incremental_condition(pre)
                 raw_slices.append(RawFileSlice(
                     raw=match_raw,
                     slice_type='templated',

--- a/test/templater_test.py
+++ b/test/templater_test.py
@@ -571,3 +571,43 @@ SELECT ${column_name} FROM ${self()}
     assert templated_slices[4].slice_type == "templated"
 
 
+def test_slice_sqlx_template_with_when_containing_nested_self(templater):
+    """${when()} block whose body contains ${self()} should be sliced correctly.
+
+    The non-greedy regex ``\\$\\{\\s*when\\((.*?)\\)\\s*\\}`` would otherwise
+    close at the inner ``${self()}``'s ``)}``, undercounting the templated
+    slice length and producing "Length of templated file mismatch with final
+    slice" during lint.
+    """
+    input_sqlx = """SELECT 1 AS x
+${when(incremental(),
+    `WHERE updated_at > (SELECT MAX(t) FROM ${self()})`)}
+"""
+    expected_sql = "SELECT 1 AS x\n\n"
+    replaced_sql, raw_slices, templated_slices = templater.slice_sqlx_template(input_sqlx)
+    assert replaced_sql == expected_sql
+    # Final slice's stop must equal the replaced length.
+    assert templated_slices[-1].templated_slice.stop == len(replaced_sql)
+
+
+def test_slice_sqlx_template_with_multiline_ref(templater):
+    """``${\\n  ref(...)\\n}`` should match across newlines.
+
+    Without DOTALL the regex fails to match, the global pass falls through to
+    ``replace_js_expressions`` which substitutes ``js_expression``, but the
+    slicing dispatch sees ``ref(`` in the raw match and returns the unchanged
+    block. The resulting slice length disagrees with the replaced length.
+    """
+    input_sqlx = """SELECT * FROM ${
+  ref({
+    schema: "events",
+    name: "extension_installed"
+  })
+} e
+"""
+    expected_sql = (
+        "SELECT * FROM `my_project.events.extension_installed` e\n"
+    )
+    replaced_sql, raw_slices, templated_slices = templater.slice_sqlx_template(input_sqlx)
+    assert replaced_sql == expected_sql
+    assert templated_slices[-1].templated_slice.stop == len(replaced_sql)


### PR DESCRIPTION
## What

Three closely related bugs in `slice_sqlx_template` produce `Length of templated file mismatch with final slice` errors during sqlfluff lint of `.sqlx` files that contain `${when(... ${self()} ...)}` blocks or multi-line `${\n  ref(...)\n}` blocks. The global templating pass hides them because `${self()}` / `${ref()}` are replaced before `replace_incremental_condition` runs, but the per-slice dispatch operates on the original raw text where the nested expressions are still present, so the slice-length accounting disagrees with the global replaced-string length.

## Bugs fixed

### 1. Dispatch ordering

The dispatch chain in `slice_sqlx_template` checked

```python
if 'ref(' in match_raw: ...
elif 'self(' in match_raw: ...
elif 'when(' in match_raw: ...
```

in priority order. A `${when(...)}` block whose body contains `${self()}` or `${ref()}` satisfies the inner-construct's substring check first and gets routed through the wrong branch entirely. Replacement length computed there has no relation to what the global pass produces.

Fix: anchor each branch with `re.match` against the **block's prefix** so dispatch identifies the construct that begins the matched block, not any nested one.

### 2. Nested-self pre-substitution

Even with dispatch routed correctly, `replace_incremental_condition`'s non-greedy `(.*?)\)\s*\}` regex closes at the inner `${self()}`'s `)}` rather than the outer when()'s closing `)}`. The global pass dodges this because `${self()}` and `${ref()}` are already substituted before `replace_incremental_condition` runs.

Fix: in the when() branch of the slicing dispatch, pre-substitute `${self()}` / `${ref()}` before calling `replace_incremental_condition`, mirroring the global-pass order.

### 3. Multi-line ref

`REF_PATTERN`'s non-greedy `(.*?)` doesn't cross newlines without DOTALL, so `${\n  ref(...)\n}` blocks fail the regex in `replace_ref_with_bq_table`. The global pass falls through to `replace_js_expressions` (substituting `js_expression`), but the slicing dispatch — seeing `ref(` in match_raw — calls `replace_ref_with_bq_table` which returns the block unchanged. Slice length and global replaced length disagree.

Fix: inline `(?s)` on `REF_PATTERN` so `.` crosses newlines at every use site (regex compile and re.search both honour the inline flag).

## Tests

Two new regression tests in `test/templater_test.py`:

- `test_slice_sqlx_template_with_when_containing_nested_self` — `${when(... ${self()} ...)}` slices correctly and final templated_slice stop equals replaced length.
- `test_slice_sqlx_template_with_multiline_ref` — `${\n  ref(...)\n}` matches and produces a single ref slice with the expected BQ table substitution.

All 28 tests pass (26 existing + 2 new).

## Bonus: mise setup

Adds `mise.toml` so contributors with [mise](https://mise.jdx.dev) can provision Python + uv + venv + test dependencies with one `mise install` and run tests via `mise run test`. The existing `compose.yml` / `Dockerfile.dev` setup is unchanged for those who prefer it.

## Test plan

- [x] `pytest test/` — 28 passed
- [x] Lint a real-world `.sqlx` file containing `${when(incremental(), \`... ${self()} ...\`)}` — no more "Length of templated file mismatch" warnings
- [x] Lint a real-world `.sqlx` file containing `${\n  ref({schema: ..., name: ...})\n}` — same

---

🤖 Investigated, fixed, and tested with [Claude Code](https://claude.com/claude-code).