### PR TITLE
chore: add 14-day cooldown to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
Dependabot の設定に 14 日間のクールダウン期間（`cooldown`）を追加しました。
これにより、新しいバージョンがリリースされてから 14 日間経過した後にプルリクエストが作成されるようになります。

対象エコシステム:
- pip
- github-actions